### PR TITLE
Смена имени языка на 1C (BSL)

### DIFF
--- a/1c.YAML-tmLanguage
+++ b/1c.YAML-tmLanguage
@@ -1,6 +1,6 @@
 # [PackageDev] target_format: plist, ext: tmLanguage
 ---
-name: 1C
+name: 1C (BSL)
 scopeName: source.bsl
 fileTypes: [bsl, os]
 uuid: cf0633ff-beee-424a-a2f7-3dce4093e139

--- a/1c.tmLanguage
+++ b/1c.tmLanguage
@@ -8,7 +8,7 @@
 		<string>os</string>
 	</array>
 	<key>name</key>
-	<string>1C</string>
+	<string>1C (BSL)</string>
 	<key>patterns</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Из обсуждения https://github.com/xDrivenDevelopment/1c-syntax/commit/35ca34226a1ca181535449e89ae707c223f95a2e

Напоминаю, что речь идет про "пользовательское" имя языка, которое пользователь редактора видит при выборе определения синтаксиса:
![default](https://cloud.githubusercontent.com/assets/1132840/11622188/8d518c32-9cd4-11e5-92ed-909b7b7919e3.png)
![2](https://cloud.githubusercontent.com/assets/1132840/11622190/8fcfc212-9cd4-11e5-8aac-190ff34309e4.png)

@vsuh отметил отсутствие единообразности в именах.

Действующие соглашения:
* внутренний идентификатор для разработчиков - `bsl`
* имя пакета, устанавливаемого через пакетный менеджер - `language-1c-bsl`

Для этого пользовательского имени предлагаю выводить `1C (BSL)` - таким образом мы, во-первых, не потеряем связь между пользовательским представлением, именем пакета и идентификатором, во-вторых, получим связь между именем языка и расширением редактируемых файлов (`bsl`).

@xDrivenDevelopment/1c-syntax Ваши мнения?