### PR TITLE
Исправлен regexp литералов-дат

### DIFF
--- a/1c.YAML-tmLanguage
+++ b/1c.YAML-tmLanguage
@@ -55,7 +55,7 @@ patterns:
     match: \b((\h{8}-(\h{4}-){3}\h{12})|\d+\.?\d*)\b
 
   - name: constant.other.date.bsl
-    match: \'((\d{8})|(\d{14}))\'
+    match: \'((\d{4}[^\d\']*\d{2}[^\d\']*\d{2})([^\d\']*\d{2}[^\d\']*\d{2}([^\d\']*\d{2})?)?)\'
 
   - name: storage.type.bsl
     match: (?i:(?<=[^\wа-яё]|^)(КонецПроцедуры|EndProcedure|КонецФункции|EndFunction)(?=[^\wа-яё]|$))


### PR DESCRIPTION
В литералах-датах учтена возможность указания разделителей для частей даты, обновлен набор вариантов указания частей даты.

Приложен diff для файла-теста.
[syntax_test_bsl.bsl.diff.zip](https://github.com/xDrivenDevelopment/1c-syntax/files/189748/syntax_test_bsl.bsl.diff.zip)
