### PR TITLE
Изменена лексема "Внутреннее соединение"

### DIFF
--- a/1c-query.YAML-tmLanguage
+++ b/1c-query.YAML-tmLanguage
@@ -46,7 +46,7 @@ patterns:
     match: (,|;)
 
   - name: keyword.control.sdbl
-    match: (?i)(?<=[^\wа-яё\.]|^)(Выбрать|Select|Разрешенные|Allowed|Различные|Distinct|Первые|Top|Как|As|ПустаяТаблица|EpmtyTable|Поместить|Into|Уничтожить|Drop|Из|From|((Левое|Left|Правое|Right|Полное|Full)\s+(Внешнее\s+|Outer\s+)?Соединение|Join)|((Внутреннее\s+|Inner\s+)?Соединение|Join)|Где|Where|(Сгруппировать\s+По)|(Group\s+By)|Имеющие|Having|Объединить(\s+Все)?|Union(\s+All)?|(Упорядочить\s+По)|(Order\s+By)|Автоупорядочивание|Autoorder|Итоги|Totals|По(\s+Общие)?|By(\s+Overall)?|(Только\s+)?Иерархия|(Only\s+)?Hierarchy|Периодами|Periods|Индексировать|Index|Выразить|Cast|Возр|Asc|Убыв|Desc|Для\s+Изменения|(For\s+Update(\s+Of)?)|Спецсимвол|Escape)(?=[^\wа-яё\.]|$)
+    match: (?i)(?<=[^\wа-яё\.]|^)(Выбрать|Select|Разрешенные|Allowed|Различные|Distinct|Первые|Top|Как|As|ПустаяТаблица|EpmtyTable|Поместить|Into|Уничтожить|Drop|Из|From|((Левое|Left|Правое|Right|Полное|Full)\s+(Внешнее\s+|Outer\s+)?Соединение|Join)|((Внутреннее|Inner)\s+Соединение|Join)|Где|Where|(Сгруппировать\s+По)|(Group\s+By)|Имеющие|Having|Объединить(\s+Все)?|Union(\s+All)?|(Упорядочить\s+По)|(Order\s+By)|Автоупорядочивание|Autoorder|Итоги|Totals|По(\s+Общие)?|By(\s+Overall)?|(Только\s+)?Иерархия|(Only\s+)?Hierarchy|Периодами|Periods|Индексировать|Index|Выразить|Cast|Возр|Asc|Убыв|Desc|Для\s+Изменения|(For\s+Update(\s+Of)?)|Спецсимвол|Escape)(?=[^\wа-яё\.]|$)
 
   - comment: "Функции языка запросов"
     name: support.function.sdbl


### PR DESCRIPTION
Убрал `?` из `((Внутреннее\s+|Inner\s+)?Соединение|Join)`, а то получается подсвечивается одинокое слово "СОЕДИНЕНИЕ".
В редакторе Atom подтвержено ошибочное поведение.